### PR TITLE
Fixed issue with logger being called on validate

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,11 +13,11 @@ module.exports = class FootprintsTrailpack extends Trailpack {
     this.modelFootprints = true
 
     if (!this.app.api.services.FootprintService) {
-      this.log.warn('trailpack-footprints is installed, but FootprintService is not provided')
+      this.app.logger.warn('trailpack-footprints is installed, but FootprintService is not provided')
       this.modelFootprints = false
     }
     if (!this.app.api.controllers.FootprintController) {
-      this.log.warn('trailpack-footprints is installed, but FootprintController is not provided')
+      this.app.logger.warn('trailpack-footprints is installed, but FootprintController is not provided')
       this.modelFootprints = false
     }
   }


### PR DESCRIPTION
This is the error I fixed:
```
debug: trailpack: validating footprints
TypeError: Cannot read property 'warn' of undefined
    at FootprintsTrailpack.validate (/Users/Matteo/Developer/projects/Yeeti/Hamsa/hamsa-api-server/node_modules/trailpack-footprints/index.js:23:19)
    at app.after.then.then (/Users/Matteo/Developer/projects/Yeeti/Hamsa/hamsa-api-server/node_modules/trails/lib/Core.js:188:24)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
    at Function.Module.runMain (module.js:703:11)
    at startup (bootstrap_node.js:190:16)
    at bootstrap_node.js:662:3
(node:30120) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'warn' of undefined
    at FootprintsTrailpack.validate (/Users/Matteo/Developer/projects/Yeeti/Hamsa/hamsa-api-server/node_modules/trailpack-footprints/index.js:23:19)
    at app.after.then.then (/Users/Matteo/Developer/projects/Yeeti/Hamsa/hamsa-api-server/node_modules/trails/lib/Core.js:188:24)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:160:7)
    at Function.Module.runMain (module.js:703:11)
    at startup (bootstrap_node.js:190:16)
    at bootstrap_node.js:662:3
```